### PR TITLE
Get a new word from mapping in case of capitals.

### DIFF
--- a/eng/_replacement.py
+++ b/eng/_replacement.py
@@ -24,7 +24,7 @@ class Replacement(typing.NamedTuple):
                 col_offset = token.start[1]
             for match in REX_WORD.finditer(line):
                 old_word = match.group(0)
-                new_word = words.get(old_word)
+                new_word = words.get(old_word.lower())
                 if new_word is None:
                     continue
                 if old_word.istitle():


### PR DESCRIPTION
When using your library, I could see that it does not handle upper case letters, ie. "Organization" is not converted to "Organisation". Adding `lower()` function when getting word form mapping seems to resolve this problem. If you think it is not correct or you have any other idea, please let me know.