### PR TITLE
remove space before 'meter' and 'meters

### DIFF
--- a/eng/words.txt
+++ b/eng/words.txt
@@ -1029,10 +1029,10 @@ mesmerising	mesmerizing
 metabolise	metabolize
 metabolised	metabolized
 metabolises	metabolizes
-metabolising	metabolizing
-metre	 meter
-metres	 meters
-micrometre	micrometer
+metabolising  metabolizing
+metre  meter
+metres  meters
+micrometre  micrometer
 micrometres	micrometers
 militarise	militarize
 militarised	militarized


### PR DESCRIPTION
Hello, 
I have noticed that before 'meters' and 'meter' are spaces. I am not sure if I fix it with this commit (maybe need another one)